### PR TITLE
Don't include \0 in string

### DIFF
--- a/exif.cpp
+++ b/exif.cpp
@@ -85,9 +85,12 @@ namespace {
         for(unsigned i=0; i<num_components; ++i, j -= j_m) {
             value[i] = data >> j & 0xff;
         }
+        if (value[num_components - 1] == '\0') {
+          value.resize(num_components - 1);
+        }
     } else {
       if (base+data+num_components <= len)
-        value.assign( (const char*)(buf+base+data), num_components );
+        value.assign( (const char*)(buf+base+data), num_components - 1 );
     }
     return value;
   }


### PR DESCRIPTION
std::string::assign(const char * s, size_t n) copies `n` characters from `s`. As per EXIF standard http://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf 4.6.2, ASCII strings are null terminated. So original line included \0 terminating byte, so subtract 1 to load just the text without \0 terminator.