### PR TITLE
Remove redundant std::move [-Wpessimizing-move]

### DIFF
--- a/exif.cpp
+++ b/exif.cpp
@@ -403,9 +403,9 @@ IFEntry parseIFEntry(const unsigned char *buf, const unsigned offs,
                      const bool alignIntel, const unsigned base,
                      const unsigned len) {
   if (alignIntel) {
-    return std::move(parseIFEntry_temp<true>(buf, offs, base, len));
+    return parseIFEntry_temp<true>(buf, offs, base, len);
   } else {
-    return std::move(parseIFEntry_temp<false>(buf, offs, base, len));
+    return parseIFEntry_temp<false>(buf, offs, base, len);
   }
 }
 }


### PR DESCRIPTION
As correctly warned by Clang, moving temporary objects prevents copy elision from happening, whereas the copy of a temporary return value is elided in virtually all modern C++ compilers, and soon required by C++17 too.