### PR TITLE
Fix flash detection.

### DIFF
--- a/exif.cpp
+++ b/exif.cpp
@@ -646,7 +646,8 @@ int easyexif::EXIFInfo::parseFromEXIFSegment(const unsigned char *buf,
 
         case 0x9209:
           // Flash used
-          if (result.format() == 3) this->Flash = result.data() ? 1 : 0;
+          if (result.format() == 3 && result.val_short().size())
+            this->Flash = (result.val_short().front() & (1 << 0)) >> 0;
           break;
 
         case 0x920a:

--- a/test-images/bb-android.jpg.expected
+++ b/test-images/bb-android.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/2.2
 ISO speed            : 50
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 2
 Lens focal length    : 4.750000 mm
 35mm focal length    : 27 mm

--- a/test-images/evil1.jpg.expected
+++ b/test-images/evil1.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/2.8
 ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 5
 Lens focal length    : 7.406250 mm
 35mm focal length    : 0 mm

--- a/test-images/lukas12p.jpg.expected
+++ b/test-images/lukas12p.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/4.5
 ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 2
 Lens focal length    : 14.000000 mm
 35mm focal length    : 0 mm

--- a/test-images/short-ascii-MM.jpg.expected
+++ b/test-images/short-ascii-MM.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/4.9
 ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 2
 Lens focal length    : 21.300000 mm
 35mm focal length    : 0 mm

--- a/test-images/sony-alpha-6000.jpg.expected
+++ b/test-images/sony-alpha-6000.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/8.0
 ISO speed            : 100
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 5
 Lens focal length    : 22.000000 mm
 35mm focal length    : 33 mm

--- a/test-images/test2.jpg.expected
+++ b/test-images/test2.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/2.4
 ISO speed            : 80
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 5
 Lens focal length    : 4.280000 mm
 35mm focal length    : 35 mm

--- a/test-images/test3.jpg.expected
+++ b/test-images/test3.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/2.4
 ISO speed            : 500
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 5
 Lens focal length    : 4.280000 mm
 35mm focal length    : 35 mm


### PR DESCRIPTION
As specified by the specification (http://www.cipa.jp/std/documents/e/DC-008-Translation-2016-E.pdf, page 57), whether the flash was fired or not is stored on the least significant bit of the 0x9209 tag.
Also fixed expected output of some test images which incorrectly report flash usage.