### PR TITLE
Fix flash fired detection and implement flash mode and flash return light

### DIFF
--- a/demo.cpp
+++ b/demo.cpp
@@ -54,6 +54,8 @@ int main(int argc, char *argv[]) {
   printf("Subject distance     : %f m\n", result.SubjectDistance);
   printf("Exposure bias        : %f EV\n", result.ExposureBiasValue);
   printf("Flash used?          : %d\n", result.Flash);
+  printf("Flash returned light : %d\n", result.FlashReturnedLight);
+  printf("Flash mode           : %d\n", result.FlashMode);
   printf("Metering mode        : %d\n", result.MeteringMode);
   printf("Lens focal length    : %f mm\n", result.FocalLength);
   printf("35mm focal length    : %u mm\n", result.FocalLengthIn35mm);

--- a/exif.cpp
+++ b/exif.cpp
@@ -646,7 +646,8 @@ int easyexif::EXIFInfo::parseFromEXIFSegment(const unsigned char *buf,
 
         case 0x9209:
           // Flash used
-          if (result.format() == 3) this->Flash = result.data() ? 1 : 0;
+          if (result.format() == 3 && result.val_short().size())
+            this->Flash = (result.val_short().front() & (1 << 0)) >> 0;
           break;
 
         case 0x920a:

--- a/exif.cpp
+++ b/exif.cpp
@@ -646,8 +646,13 @@ int easyexif::EXIFInfo::parseFromEXIFSegment(const unsigned char *buf,
 
         case 0x9209:
           // Flash used
-          if (result.format() == 3 && result.val_short().size())
-            this->Flash = result.val_short().front() & 1;
+          if (result.format() == 3 && result.val_short().size()) {
+            uint16_t data = result.val_short().front();
+            
+            this->Flash = data & 1;
+            this->FlashReturnedLight = (data & 6) >> 1;
+            this->FlashMode = (data & 24) >> 3;
+          }
           break;
 
         case 0x920a:
@@ -868,6 +873,8 @@ void easyexif::EXIFInfo::clear() {
   FocalLength = 0;
   FocalLengthIn35mm = 0;
   Flash = 0;
+  FlashReturnedLight = 0;
+  FlashMode = 0;
   MeteringMode = 0;
   ImageWidth = 0;
   ImageHeight = 0;

--- a/exif.cpp
+++ b/exif.cpp
@@ -647,7 +647,7 @@ int easyexif::EXIFInfo::parseFromEXIFSegment(const unsigned char *buf,
         case 0x9209:
           // Flash used
           if (result.format() == 3 && result.val_short().size())
-            this->Flash = (result.val_short().front() & (1 << 0)) >> 0;
+            this->Flash = result.val_short().front() & 1;
           break;
 
         case 0x920a:

--- a/exif.h
+++ b/exif.h
@@ -88,6 +88,16 @@ class EXIFInfo {
   double FocalLength;               // Focal length of lens in millimeters
   unsigned short FocalLengthIn35mm; // Focal length in 35mm film
   char Flash;                       // 0 = no flash, 1 = flash used
+  unsigned short FlashReturnedLight;// Flash returned light status
+                                    // 0: No strobe return detection function
+                                    // 1: Reserved
+                                    // 2: Strobe return light not detected
+                                    // 3: Strobe return light detected
+  unsigned short FlashMode;         // Flash mode
+                                    // 0: Unknown
+                                    // 1: Compulsory flash firing
+                                    // 2: Compulsory flash suppression
+                                    // 3: Automatic mode
   unsigned short MeteringMode;      // Metering mode
                                     // 1: average
                                     // 2: center weighted average

--- a/test-images/bb-android.jpg.expected
+++ b/test-images/bb-android.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/2.2
 ISO speed            : 50
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 2
 Lens focal length    : 4.750000 mm
 35mm focal length    : 27 mm

--- a/test-images/bb-android.jpg.expected
+++ b/test-images/bb-android.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 50
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 2
 Metering mode        : 2
 Lens focal length    : 4.750000 mm
 35mm focal length    : 27 mm

--- a/test-images/down-mirrored.jpg.expected
+++ b/test-images/down-mirrored.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 0
 Metering mode        : 0
 Lens focal length    : 0.000000 mm
 35mm focal length    : 0 mm

--- a/test-images/evil1.jpg.expected
+++ b/test-images/evil1.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 2
 Metering mode        : 5
 Lens focal length    : 7.406250 mm
 35mm focal length    : 0 mm

--- a/test-images/evil1.jpg.expected
+++ b/test-images/evil1.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/2.8
 ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 5
 Lens focal length    : 7.406250 mm
 35mm focal length    : 0 mm

--- a/test-images/lens_info.jpg.expected
+++ b/test-images/lens_info.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 0
 Metering mode        : 0
 Lens focal length    : 0.000000 mm
 35mm focal length    : 0 mm

--- a/test-images/lukas12p.jpg.expected
+++ b/test-images/lukas12p.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 1
 Metering mode        : 2
 Lens focal length    : 14.000000 mm
 35mm focal length    : 0 mm

--- a/test-images/lukas12p.jpg.expected
+++ b/test-images/lukas12p.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/4.5
 ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 2
 Lens focal length    : 14.000000 mm
 35mm focal length    : 0 mm

--- a/test-images/right.jpg.expected
+++ b/test-images/right.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 0
 Metering mode        : 0
 Lens focal length    : 0.000000 mm
 35mm focal length    : 0 mm

--- a/test-images/short-ascii-II.jpg.expected
+++ b/test-images/short-ascii-II.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 250
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 1
+Flash returned light : 0
+Flash mode           : 1
 Metering mode        : 2
 Lens focal length    : 3.510000 mm
 35mm focal length    : 0 mm

--- a/test-images/short-ascii-MM.jpg.expected
+++ b/test-images/short-ascii-MM.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 3
 Metering mode        : 2
 Lens focal length    : 21.300000 mm
 35mm focal length    : 0 mm

--- a/test-images/short-ascii-MM.jpg.expected
+++ b/test-images/short-ascii-MM.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/4.9
 ISO speed            : 0
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 2
 Lens focal length    : 21.300000 mm
 35mm focal length    : 0 mm

--- a/test-images/sony-alpha-6000.jpg.expected
+++ b/test-images/sony-alpha-6000.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 100
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 2
 Metering mode        : 5
 Lens focal length    : 22.000000 mm
 35mm focal length    : 33 mm

--- a/test-images/sony-alpha-6000.jpg.expected
+++ b/test-images/sony-alpha-6000.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/8.0
 ISO speed            : 100
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 5
 Lens focal length    : 22.000000 mm
 35mm focal length    : 33 mm

--- a/test-images/test1.jpg.expected
+++ b/test-images/test1.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 50
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 0
 Metering mode        : 5
 Lens focal length    : 4.280000 mm
 35mm focal length    : 35 mm

--- a/test-images/test2.jpg.expected
+++ b/test-images/test2.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/2.4
 ISO speed            : 80
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 5
 Lens focal length    : 4.280000 mm
 35mm focal length    : 35 mm

--- a/test-images/test2.jpg.expected
+++ b/test-images/test2.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 80
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 2
 Metering mode        : 5
 Lens focal length    : 4.280000 mm
 35mm focal length    : 35 mm

--- a/test-images/test3.jpg.expected
+++ b/test-images/test3.jpg.expected
@@ -17,6 +17,8 @@ ISO speed            : 500
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
 Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 2
 Metering mode        : 5
 Lens focal length    : 4.280000 mm
 35mm focal length    : 35 mm

--- a/test-images/test3.jpg.expected
+++ b/test-images/test3.jpg.expected
@@ -16,7 +16,7 @@ F-stop               : f/2.4
 ISO speed            : 500
 Subject distance     : 0.000000 m
 Exposure bias        : 0.000000 EV
-Flash used?          : 1
+Flash used?          : 0
 Metering mode        : 5
 Lens focal length    : 4.280000 mm
 35mm focal length    : 35 mm


### PR DESCRIPTION
As specified by the specification (http://www.cipa.jp/std/documents/e/DC-008-Translation-2016-E.pdf, page 57), whether the flash was fired or not is stored on the least significant bit of the 0x9209 tag.
Also fixed expected output of some test images which incorrectly report flash usage.

Also add implementation for flash mode (automatic, compulsory, inhibited) and flash strobe return light.