### PR TITLE
FIX - EOI sanity check bug

### DIFF
--- a/exif.cpp
+++ b/exif.cpp
@@ -418,23 +418,20 @@ int easyexif::EXIFInfo::parseFrom(const unsigned char *buf, unsigned len) {
   if (!buf || len < 4) return PARSE_EXIF_ERROR_NO_JPEG;
   if (buf[0] != 0xFF || buf[1] != 0xD8) return PARSE_EXIF_ERROR_NO_JPEG;
 
-  // Sanity check: some cameras pad the JPEG image with null bytes at the end.
-  // Normally, we should able to find the JPEG end marker 0xFFD9 at the end
-  // of the image, but not always. As long as there are null/0xFF bytes at the
-  // end of the image buffer, keep decrementing len until an 0xFFD9 is found,
-  // or some other bytes are. If the first non-zero/0xFF bytes from the end are
-  // not 0xFFD9, then we can be reasonably sure that the buffer is not a JPEG.
+  // Sanity check: some cameras pad the JPEG image with some bytes at the end.
+  // Normally, we should be able to find the JPEG end marker 0xFFD9 at the end
+  // of the image buffer, but not always. As long as there are some bytes
+  // except 0xD9 at the end of the image buffer, keep decrementing len until
+  // an 0xFFD9 is found. If JPEG end marker 0xFFD9 is not found,
+  // then we can be reasonably sure that the buffer is not a JPEG.
   while (len > 2) {
-    if (buf[len - 1] == 0 || buf[len - 1] == 0xFF) {
-      len--;
-    } else {
-      if (buf[len - 1] != 0xD9 || buf[len - 2] != 0xFF) {
-        return PARSE_EXIF_ERROR_NO_JPEG;
-      } else {
-        break;
-      }
-    }
+    if (buf[len - 1] == 0xD9 && buf[len - 2] == 0xFF)
+      break;
+    len--;
   }
+  if (len <= 2)
+    return PARSE_EXIF_ERROR_NO_JPEG;
+
   clear();
 
   // Scan for EXIF header (bytes 0xFF 0xE1) and do a sanity check by


### PR DESCRIPTION
### Problem
- #17
- A section between `EOI` and `EOF` can be filled with any values except `0xFFD9`. But easyexif only checks `0x00` and `0xFF`.

### Changes
- Changed sanity check codes to find `0xFFD9` directly.