### PR TITLE
cmake added and some support for color profile identification.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ demo
 *.exe
 *.out
 *.app
+
+# Idea
+.idea/**
+
+# build dirs
+cmake-build-*/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.7)
 project(easyexif)
 
+if(VERBOSE)
+    add_definitions(-DDEBUG_COUT)
+endif()
+
 set(CMAKE_CXX_STANDARD 14)
 
 add_executable(demo demo.cpp exif.cpp exif.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.7)
+project(easyexif)
+
+set(CMAKE_CXX_STANDARD 14)
+
+add_executable(demo demo.cpp exif.cpp exif.h)

--- a/demo.cpp
+++ b/demo.cpp
@@ -34,6 +34,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Dump EXIF information
+  printf("InteropIndex         : %s\n", result.InteropIndex.c_str());
   printf("Camera make          : %s\n", result.Make.c_str());
   printf("Camera model         : %s\n", result.Model.c_str());
   printf("Software             : %s\n", result.Software.c_str());

--- a/demo.cpp
+++ b/demo.cpp
@@ -39,6 +39,7 @@ int main(int argc, char *argv[]) {
   printf("Camera model         : %s\n", result.Model.c_str());
   printf("Software             : %s\n", result.Software.c_str());
   printf("Bits per sample      : %d\n", result.BitsPerSample);
+  printf("Color Space          : %d\n", result.ColorSpace);
   printf("Image width          : %d\n", result.ImageWidth);
   printf("Image height         : %d\n", result.ImageHeight);
   printf("Image description    : %s\n", result.ImageDescription.c_str());

--- a/exif.cpp
+++ b/exif.cpp
@@ -681,7 +681,13 @@ int easyexif::EXIFInfo::parseFromEXIFSegment(const unsigned char *buf,
           if (result.format() == 2)
             this->SubSecTimeOriginal = result.val_string();
           break;
-
+        case 0xa001:
+          // Color Space info
+          if (result.format() == 3 && result.val_short().size()) {
+              uint16_t data = result.val_short().front();
+              this->ColorSpace = data;
+          }
+          break;
         case 0xa002:
           // EXIF Image width
           if (result.format() == 4 && result.val_long().size())
@@ -754,6 +760,11 @@ int easyexif::EXIFInfo::parseFromEXIFSegment(const unsigned char *buf,
           if (result.format() == 2) {
             this->LensInfo.Model = result.val_string();
           }
+          break;
+      default:
+#ifdef DEBUG_COUT
+          std::cout << "Unknown tag: " << result.tag() << std::endl;
+#endif
           break;
       }
       offs += 12;
@@ -916,6 +927,7 @@ void easyexif::EXIFInfo::clear() {
   FlashReturnedLight = 0;
   FlashMode = 0;
   MeteringMode = 0;
+  ColorSpace = 0;
   ImageWidth = 0;
   ImageHeight = 0;
 

--- a/exif.h
+++ b/exif.h
@@ -118,6 +118,7 @@ class EXIFInfo {
                                     // 3: spot
                                     // 4: multi-spot
                                     // 5: multi-segment
+  unsigned ColorSpace;              // Color Spaced reported in EXIF data
   unsigned ImageWidth;              // Image width reported in EXIF data
   unsigned ImageHeight;             // Image height reported in EXIF data
   struct Geolocation_t {            // GPS information embedded in file

--- a/exif.h
+++ b/exif.h
@@ -35,6 +35,9 @@
 #define __EXIF_H
 
 #include <string>
+#ifdef DEBUG_COUT
+  #include <iostream>
+#endif
 
 namespace easyexif {
 
@@ -62,6 +65,7 @@ class EXIFInfo {
 
   // Data fields filled out by parseFrom()
   char ByteAlign;                   // 0 = Motorola byte alignment, 1 = Intel
+  std::string InteropIndex;         // InteropIndex. Used to detect sRGB vs AdobeRGB
   std::string ImageDescription;     // Image description
   std::string Make;                 // Camera manufacturer's name
   std::string Model;                // Camera model

--- a/test-images/AdobeRGB.jpg.expected
+++ b/test-images/AdobeRGB.jpg.expected
@@ -1,0 +1,39 @@
+InteropIndex         : R03
+Camera make          : Canon
+Camera model         : Canon EOS 600D
+Software             : 
+Bits per sample      : 0
+Color Space          : 65535
+Image width          : 5184
+Image height         : 3456
+Image description    : 
+Image orientation    : 1
+Image copyright      : 
+Image date/time      : 2019:03:13 17:44:36
+Original date/time   : 2019:03:13 17:44:36
+Digitize date/time   : 2019:03:13 17:44:36
+Subsecond time       : 26
+Exposure time        : 1/3 s
+F-stop               : f/13.0
+Exposure program     : 1
+ISO speed            : 400
+Subject distance     : 0.000000 m
+Exposure bias        : 0.000000 EV
+Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 2
+Metering mode        : 3
+Lens focal length    : 50.000000 mm
+35mm focal length    : 0 mm
+GPS Latitude         : 0.000000 deg (0.000000 deg, 0.000000 min, 0.000000 sec ?)
+GPS Longitude        : 0.000000 deg (0.000000 deg, 0.000000 min, 0.000000 sec ?)
+GPS Altitude         : 0.000000 m
+GPS Precision (DOP)  : 0.000000
+Lens min focal length: 50.000000 mm
+Lens max focal length: 50.000000 mm
+Lens f-stop min      : f/0.0
+Lens f-stop max      : f/0.0
+Lens make            : 
+Lens model           : EF50mm f/1.8 STM
+Focal plane XRes     : 5728.176796
+Focal plane YRes     : 5808.403361

--- a/test-images/bb-android.jpg.expected
+++ b/test-images/bb-android.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : QCOM-AA
 Camera model         : QCAM-AA
 Software             : IMX230-S-21
 Bits per sample      : 0
+Color Space          : 1
 Image width          : 3672
 Image height         : 4896
 Image description    : 

--- a/test-images/down-mirrored.jpg.expected
+++ b/test-images/down-mirrored.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : 
 Camera model         : 
 Software             : 
 Bits per sample      : 0
+Color Space          : 0
 Image width          : 0
 Image height         : 0
 Image description    : 

--- a/test-images/evil1.jpg.expected
+++ b/test-images/evil1.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : Canon
 Camera model         : Canon PowerShot S400
 Software             : Adobe Photoshop 7.0
 Bits per sample      : 0
+Color Space          : 1
 Image width          : 400
 Image height         : 300
 Image description    : 

--- a/test-images/lens_info.jpg.expected
+++ b/test-images/lens_info.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : 
 Camera model         : 
 Software             : 
 Bits per sample      : 0
+Color Space          : 65535
 Image width          : 0
 Image height         : 0
 Image description    : 

--- a/test-images/lukas12p.jpg.expected
+++ b/test-images/lukas12p.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : OLYMPUS IMAGING CORP.
 Camera model         : E-510
 Software             : ACD Systems Digital Imaging
 Bits per sample      : 0
+Color Space          : 0
 Image width          : 912
 Image height         : 684
 Image description    : OLYMPUS DIGITAL CAMERA

--- a/test-images/right.jpg.expected
+++ b/test-images/right.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : 
 Camera model         : 
 Software             : 
 Bits per sample      : 0
+Color Space          : 0
 Image width          : 0
 Image height         : 0
 Image description    : 

--- a/test-images/sRGB.jpg.expected
+++ b/test-images/sRGB.jpg.expected
@@ -1,0 +1,39 @@
+InteropIndex         : R98
+Camera make          : Canon
+Camera model         : Canon EOS 600D
+Software             : 
+Bits per sample      : 0
+Color Space          : 1
+Image width          : 5184
+Image height         : 3456
+Image description    : 
+Image orientation    : 1
+Image copyright      : 
+Image date/time      : 2019:03:13 17:44:29
+Original date/time   : 2019:03:13 17:44:29
+Digitize date/time   : 2019:03:13 17:44:29
+Subsecond time       : 02
+Exposure time        : 1/3 s
+F-stop               : f/13.0
+Exposure program     : 1
+ISO speed            : 400
+Subject distance     : 0.000000 m
+Exposure bias        : 0.000000 EV
+Flash used?          : 0
+Flash returned light : 0
+Flash mode           : 2
+Metering mode        : 3
+Lens focal length    : 50.000000 mm
+35mm focal length    : 0 mm
+GPS Latitude         : 0.000000 deg (0.000000 deg, 0.000000 min, 0.000000 sec ?)
+GPS Longitude        : 0.000000 deg (0.000000 deg, 0.000000 min, 0.000000 sec ?)
+GPS Altitude         : 0.000000 m
+GPS Precision (DOP)  : 0.000000
+Lens min focal length: 50.000000 mm
+Lens max focal length: 50.000000 mm
+Lens f-stop min      : f/0.0
+Lens f-stop max      : f/0.0
+Lens make            : 
+Lens model           : EF50mm f/1.8 STM
+Focal plane XRes     : 5728.176796
+Focal plane YRes     : 5808.403361

--- a/test-images/short-ascii-II.jpg.expected
+++ b/test-images/short-ascii-II.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : XIAOMI
 Camera model         : MI3
 Software             : 
 Bits per sample      : 0
+Color Space          : 1
 Image width          : 4208
 Image height         : 3120
 Image description    : 

--- a/test-images/short-ascii-MM.jpg.expected
+++ b/test-images/short-ascii-MM.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : R98
 Camera make          : Canon
 Camera model         : S40
 Software             : 
 Bits per sample      : 0
+Color Space          : 1
 Image width          : 2272
 Image height         : 1704
 Image description    : 

--- a/test-images/sony-alpha-6000.jpg.expected
+++ b/test-images/sony-alpha-6000.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : R98
 Camera make          : SONY
 Camera model         : ILCE-6000
 Software             : ILCE-6000 v1.00
 Bits per sample      : 0
+Color Space          : 1
 Image width          : 6000
 Image height         : 4000
 Image description    :                                

--- a/test-images/test1.jpg.expected
+++ b/test-images/test1.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : Apple
 Camera model         : iPhone 4S
 Software             : 6.1
 Bits per sample      : 0
+Color Space          : 1
 Image width          : 3264
 Image height         : 2448
 Image description    : 

--- a/test-images/test2.jpg.expected
+++ b/test-images/test2.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : Apple
 Camera model         : iPhone 4S
 Software             : 6.0.1
 Bits per sample      : 0
+Color Space          : 1
 Image width          : 1319
 Image height         : 1040
 Image description    : 

--- a/test-images/test3.jpg.expected
+++ b/test-images/test3.jpg.expected
@@ -1,7 +1,9 @@
+InteropIndex         : 
 Camera make          : Apple
 Camera model         : iPhone 4S
 Software             : 6.0.1
 Bits per sample      : 0
+Color Space          : 1
 Image width          : 3264
 Image height         : 2448
 Image description    : 


### PR DESCRIPTION
I have added a CMakeLists file so that the project can be built with Jetbrains' CLion IDE.
Additionally, I have added support for the ColorSpace and InteropIndex EXIF Tags. These allow the end-user to differentiate between AdobeRGB and sRGB. This feature is important for proper image decoding.